### PR TITLE
Adding volume expansion K8s config

### DIFF
--- a/ansible/playbooks/pvc/storage-class.yml.j2
+++ b/ansible/playbooks/pvc/storage-class.yml.j2
@@ -6,6 +6,7 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: ebs.csi.aws.com
 volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
 parameters:
   csi.storage.k8s.io/fstype: ext4
   type: gp3


### PR DESCRIPTION
Added k8s parm to allow volume resizing.

This resizing would be accomplished by updating the chainlet template that defines the size of the PV.

So, by default (today), it is 100G. It would need to be updated to say, 120G, and then redeployed. This will then scale out the persistent volume storage from 100G to 120G without decommissioning the existing PV.

Note: This will likely require Controller changes in the future so that the Controller can read the size of an existing PVC and use that for a deployment, instead of using the default value. This would be the scenario if a deployment already exists.