### PR TITLE
Decrease severity of not producing blocks alert

### DIFF
--- a/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/chainlets-rules.yaml
+++ b/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/chainlets-rules.yaml
@@ -34,7 +34,7 @@ spec:
         summary: No blocks produced in the last minute
       expr: delta(cometbft_consensus_height{app="chainlet"}[1m]) < 1
       labels:
-        severity: critical
+        severity: warning
     - alert: ChainletAverageBlockTimeTooLong
       annotations:
         description: Average block time for *{{ $labels.chainId }}* is *{{ $value }}* seconds


### PR DESCRIPTION
The ChainletNotProducingBlocks alert often triggers during chainlets upgrades, in which case it should be ok to not have new blocks, so to avoid false positives this PR sets the alert to warning instead of critical
Provided that we already have another critical alert, ChainletMissedBlocks, which would indicate if we're getting behind for real vs if the chainlet is halted for upgrade or something 