### PR TITLE
Alerts rework

### DIFF
--- a/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/blockscout-rules.yaml
+++ b/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/blockscout-rules.yaml
@@ -9,8 +9,20 @@ spec:
     rules:
     - alert: BlockscoutIndexingFallingBehind
       annotations:
-        description: Indexing of *{{ $labels.chainId }}* is only *{{ $value }}%*
-        summary: Indexing is behind 95%
-      expr: sum(blockscout_total_blocks) by (chainId) / sum(cometbft_consensus_height) by (chainId) * 100 < 95
+        description: Indexer is *{{ $value }}* blocks behind (or metrics missing) for ≥20m.
+        summary: Indexing is behind on *{{ $labels.chainId }}*
+      expr: |
+        clamp_min(
+          sum by (chainId) (
+            max_over_time(cometbft_consensus_height[20m])
+          )
+          -
+          sum by (chainId) (
+            max_over_time(blockscout_total_blocks[20m])
+          ),
+          0
+        ) > 1000
+        OR absent(blockscout_total_blocks) OR absent(cometbft_consensus_height)
+      for: 20m
       labels:
         severity: warning

--- a/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/chainlets-rules.yaml
+++ b/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/chainlets-rules.yaml
@@ -9,43 +9,108 @@ spec:
     rules:
     - alert: ChainletJailedValidator
       annotations:
-        description: Jailed validator *{{ $labels.moniker }}* on *{{ $labels.chainId }}*
-        summary: Jailed validator
-      expr: sum(cosmos_validators_jailed{app="cosmos-exporter"}) by (moniker, chainId) > 0
+        summary: Validator(s) jailed: *{{ $labels.moniker }}*
+        description: *{{ $labels.moniker }}* on *{{ $labels.chainId }}* has been jailed (or metric missing) for ≥15m.
+      expr: |
+        sum without (address, app, instance, job) (
+          max_over_time(cosmos_validators_jailed{app="cosmos-exporter"}[15m])
+        ) > 0
+        OR absent(cosmos_validators_jailed{app="cosmos-exporter"})
+      for: 15m
       labels:
         severity: warning
     - alert: ChainletByzantineValidator
       annotations:
         description: Byzantine validator(s) on *{{ $labels.chainId }}* ({{ $value }})
         summary: Byzantine validator
-      expr: sum(cometbft_consensus_byzantine_validators{app="chainlet"}) by (chainId) > 0
+      expr: |
+        sum without(app, instance, job, chainId) (
+          max_over_time(cometbft_consensus_byzantine_validators{app="chainlet"}[15m])
+        ) > 0
+        OR absent(cometbft_consensus_byzantine_validators{app="chainlet"})
+      for: 15m
       labels:
         severity: critical
-    - alert: ChainletMissedBlocks
+    - alert: ChainletMissedBlocksWarning
       annotations:
         description: "*{{ $labels.moniker }}* missed *{{ $value }}* blocks on *{{ $labels.chainId }}* in 5 minutes"
         summary: Missed more than 10 blocks in 5m
-      expr: delta(cosmos_validators_missed_blocks{app="cosmos-exporter"}[5m]) > 10
+      expr: |
+        sum without (address, app, instance, job)(
+          clamp_min(
+            increase(cosmos_validators_missed_blocks{app="cosmos-exporter"}[5m]), 0
+          )
+        ) > 10
+        OR absent(cosmos_validators_missed_blocks{app="cosmos-exporter"})
+      labels:
+        severity: warning
+      for: 5m
+    - alert: ChainletMissedBlocks
+      annotations:
+        description: "*{{ $labels.moniker }}* missed *{{ $value }}* blocks on *{{ $labels.chainId }}* in 15 minutes"
+        summary: Missed more than 50 blocks in 15m
+      expr: |
+        sum without (address, app, instance, job)(
+          clamp_min(
+            increase(cosmos_validators_missed_blocks{app="cosmos-exporter"}[15m]), 0
+          )
+        ) > 50
+        OR absent(cosmos_validators_missed_blocks{app="cosmos-exporter"})
       labels:
         severity: critical
+      for: 15m
+    - alert: ChainletNotProducingBlocksWarning
+      annotations:
+        description: "*{{ $labels.chainId }}* didn't produced blocks in the last 5 minutes"
+        summary: No blocks produced in the last 5 minutes
+      expr: |
+        (
+          sum without(app, instance, job, chainId) (
+            increase(cometbft_consensus_height{app="chainlet"}[5m])
+          ) == 0
+        )
+        OR absent(cometbft_consensus_height{app="chainlet"})
+      labels:
+        severity: warning
+      for: 5m
     - alert: ChainletNotProducingBlocks
       annotations:
-        description: "*{{ $labels.chainId }}* didn't produced blocks in the last minute"
-        summary: No blocks produced in the last minute
-      expr: delta(cometbft_consensus_height{app="chainlet"}[1m]) < 1
+        description: "*{{ $labels.chainId }}* didn't produced blocks in the last 15 minutes"
+        summary: No blocks produced in the last 15 minutes
+      expr: |
+        (
+          sum without(app, instance, job, chainId) (
+            increase(cometbft_consensus_height{app="chainlet"}[15m])
+          ) == 0
+        )
+        OR absent(cometbft_consensus_height{app="chainlet"})
       labels:
         severity: critical
+      for: 15m
     - alert: ChainletAverageBlockTimeTooLong
       annotations:
         description: Average block time for *{{ $labels.chainId }}* is *{{ $value }}* seconds
         summary: Average block time too long
-      expr: sum(blockscout_average_block_time) by (chainId) / 1000 > 20
+      expr: |
+        avg by (chainId) (
+          avg_over_time(blockscout_average_block_time[5m])
+        ) / 1000 > 20
+        OR absent(blockscout_average_block_time)
+      for: 5m
       labels:
         severity: warning
     - alert: ChainletMempoolTooBig
       annotations:
         description: Mempool for *{{ $labels.chainId }}* is *{{ $value }}*
         summary: Mempool bigger than 300
-      expr: sum(cometbft_mempool_size{app="chainlet"}) by (chainId) > 300
+      expr: |
+        sum without(app, instance, job, chainId) (
+          max_over_time(
+            cometbft_mempool_size{app="chainlet"}[15m]
+          )
+          > 300
+        )
+        OR absent(cometbft_mempool_size{app="chainlet"})
       labels:
-        severity: warning
+        severity: critical
+      for: 15m

--- a/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/dex-rules.yaml
+++ b/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/dex-rules.yaml
@@ -11,13 +11,19 @@ spec:
       annotations:
         description: Dex feepayer balance < 1000gas (*{{ $labels.account_name }} - {{ $labels.address }}*)
         summary: Low dex feepayer balance
-      expr: sum(cosmos_balance{chain_id="sagaevm-5464-1"}) by (account_name, address) / 1000000000000000000 < 1000
+      expr: |
+        sum(cosmos_balance{chain_id="sagaevm-5464-1"}) by (account_name, address) / 1000000000000000000 < 1000
+        OR absent(cosmos_balance{chain_id="sagaevm-5464-1"})
+      for: 15m
       labels:
-        severity: warning
+        severity: critical
     - alert: SscRelayerBalanceLow
       annotations:
         description: Relayer balance < 3 on SSC-1 (*{{ $labels.address_label }} - {{ $labels.address }}*)
         summary: Critically low ssc relayer balance
-      expr: sum(cosmos_balance{chain_id="ssc-1"}) by (account_name, address) / 1000000 < 3
+      expr: |
+        sum(cosmos_balance{chain_id="ssc-1"}) by (account_name, address) / 1000000 < 3
+        OR absent(cosmos_balance{chain_id="ssc-1"})
+      for: 15m
       labels:
-        severity: warning
+        severity: critical

--- a/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/ibc-tester-rules.yaml.j2
+++ b/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/ibc-tester-rules.yaml.j2
@@ -21,6 +21,8 @@ spec:
             status="failure"
           }[10m]
         ) > bool 0
+        OR absent(ibc_transfer_exporter)
+      for: 10m
       labels:
         severity: warning
     - alert: HubToSscIbcFailure_{{ hub_chain_id }}_{{ ssc.chain_id }}
@@ -37,6 +39,8 @@ spec:
             status="failure"
           }[10m]
         ) > bool 0
+        OR absent(ibc_transfer_exporter)
+      for: 10m
       labels:
         severity: warning
     - alert: HubToDexIbcFailure_{{ hub_chain_id }}_{{ dex_chain_id }}
@@ -53,6 +57,8 @@ spec:
             status="failure"
           }[10m]
         ) > bool 0
+        OR absent(ibc_transfer_exporter)
+      for: 10m
       labels:
         severity: warning
     - alert: DexToHubIbcFailure_{{ dex_chain_id }}_{{ hub_chain_id }}
@@ -69,5 +75,7 @@ spec:
             status="failure"
           }[10m]
         ) > bool 0
+        OR absent(ibc_transfer_exporter)
+      for: 10m
       labels:
         severity: warning

--- a/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/ingress-rules.yaml
+++ b/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/ingress-rules.yaml
@@ -11,6 +11,18 @@ spec:
       annotations:
         description: Http success rate for {{ $labels.host }} is {{ $value }}%
         summary: Http success rate (non 4|5xx return) below 95%
-      expr: sum(rate(nginx_ingress_controller_requests{controller_pod=~".*",controller_class=~".*",namespace=~".*",ingress=~".*",status!~"[4-5].*"}[2m])) by (host) / sum(rate(nginx_ingress_controller_requests{controller_pod=~".*",controller_class=~".*",namespace=~".*",ingress=~".*"}[2m])) by (host) * 100 < 95
+      expr: |
+        sum(
+          rate(
+            nginx_ingress_controller_requests{controller_pod=~".*",controller_class=~".*",namespace=~".*",ingress=~".*",status!~"[4-5].*"}[5m]
+          )
+        ) by (host) / 
+        sum(
+          rate(
+            nginx_ingress_controller_requests{controller_pod=~".*",controller_class=~".*",namespace=~".*",ingress=~".*"}[5m]
+          )
+        ) by (host) < 0.95
+        OR absent(nginx_ingress_controller_requests)
+      for: 5m
       labels:
         severity: warning

--- a/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/spc-rules.yaml
+++ b/ansible/playbooks/metrics/prometheus-operator/manifests/alertmanager/rules/spc-rules.yaml
@@ -8,37 +8,97 @@ spec:
   - name: spc-group
     rules:
     - alert: SpcJailedValidator
-      annotations:
-        description: SPC Jailed validator *{{ $labels.moniker }}*
-        summary: Jailed validator
-      expr: sum(cosmos_validators_jailed{app="spc-cosmos-exporter"}) by (moniker) > 0
+      expr: |
+        sum without (address, app, instance, job) (
+          max_over_time(cosmos_validators_jailed{app="spc-cosmos-exporter"}[15m])
+        ) > 0
+        OR absent(cosmos_validators_jailed{app="spc-cosmos-exporter"})
+      for: 15m
       labels:
         severity: critical
+      annotations:
+        summary: "Validator(s) jailed: *{{ $labels.moniker }}*"
+        description: "*{{ $labels.moniker }}* has been jailed (or metric missing) for ≥15m."
     - alert: SpcByzantineValidator
-      annotations:
-        description: Byzantine validator(s) on SPC ({{ $value }})
-        summary: SPC Byzantine validator
-      expr: sum(cometbft_consensus_byzantine_validators{app="spc"}) > 0
+      expr: |
+        sum without(instance, job) (
+          max_over_time(cometbft_consensus_byzantine_validators{app="spc"}[15m])
+        ) > 0
+        OR absent(cometbft_consensus_byzantine_validators{app="spc"})
+      for: 15m
       labels:
         severity: critical
-    - alert: SpcMissedBlocks
       annotations:
-        description: "*{{ $labels.moniker }}* missed *{{ $value }}* blocks on *SPC* in 5m"
-        summary: SPC Missed more than 10 blocks in the last 5m
-      expr: delta(cosmos_validators_missed_blocks{app="spc-cosmos-exporter"}[5m]) > 10
-      labels:
-        severity: critical
-    - alert: SpcNotProducingBlocks
-      annotations:
-        description: "SPC didn't produced blocks in the last minute"
-        summary: SPC no blocks produced in the last minute
-      expr: delta(cometbft_consensus_height{app="spc"}[1m]) < 1
-      labels:
-        severity: critical
-    - alert: SpcMempoolTooBig
-      annotations:
-        description: Mempool for SPC is *{{ $value }}*
-        summary: SPC Mempool bigger than 300
-      expr: sum(cometbft_mempool_size{app="spc"}) > 300
+        summary: "Byzantine validator(s) detected"
+        description: "At least one validator reported as byzantine in the last 15 minutes (or metric missing). Count: {{$value}}"
+    - alert: SpcMissedBlocksWarning
+      expr: |
+        sum without (address, app, instance, job)(
+          clamp_min(
+            increase(cosmos_validators_missed_blocks{app="spc-cosmos-exporter"}[5m]), 0
+          )
+        ) > 10
+        OR absent(cosmos_validators_missed_blocks{app="spc-cosmos-exporter"})
+      for: 5m
       labels:
         severity: warning
+      annotations:
+        summary: "{{$labels.moniker}} missed >10 blocks in 5m"
+        description: "Validator {{$labels.moniker}} missed {{$value}} blocks over 5 minutes (or metric missing)."
+    - alert: SpcMissedBlocks
+      expr: |
+        sum without (address, app, instance, job)(
+          clamp_min(
+            increase(cosmos_validators_missed_blocks{app="spc-cosmos-exporter"}[15m]), 0
+          )
+        ) > 50
+        OR absent(cosmos_validators_missed_blocks{app="spc-cosmos-exporter"})
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        summary: "{{$labels.moniker}} missed a high number of blocks"
+        description: "Validator {{$labels.moniker}} missed {{$value}} blocks in 15 minutes (or metric missing)."
+    - alert: SpcNotProducingBlocksWarning
+      expr: |
+        (
+          sum without(instance, job) (
+            increase(cometbft_consensus_height{app="spc"}[5m])
+          ) == 0
+        )
+        OR absent(cometbft_consensus_height{app="spc"})
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "SPC has not produced blocks for ≥5 minutes"
+        description: "No increase in cometbft_consensus_height over the last 5m (or the metric is missing)."
+    - alert: SpcNotProducingBlocks
+      expr: |
+        (
+          sum without(instance, job) (
+            increase(cometbft_consensus_height{app="spc"}[15m])
+          ) == 0
+        )
+        OR absent(cometbft_consensus_height{app="spc"})
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        summary: "SPC has not produced blocks for ≥15 minutes"
+        description: "No increase in cometbft_consensus_height over the last 15m (or the metric is missing)."
+    - alert: SpcMempoolTooBig
+      expr: |
+        (
+          max_over_time(
+            cometbft_mempool_size{app="spc"}[15m]
+          )
+          > 300
+        )
+        OR absent(cometbft_mempool_size{app="spc"})
+      for: 15m
+      labels:
+        severity: critical
+      annotations:
+        summary: "SPC mempool critically large on {{$labels.instance}}"
+        description: "Mempool stuck above 300 tx for ≥15m (or metric missing). Current: {{$value}}."


### PR DESCRIPTION
This commit massively changes alert rules for SPC, Dex and other chainlets, Ingress, IBC and Blockscout.
- Add a holdoff timer for all alerts
- Add absence checks for all alerts
- Change time intervals and threshold numbers

This change should make alerts less noisy and also more informative same time.