### PR TITLE
Ethproxy for user chainlets

### DIFF
--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -12,7 +12,7 @@
           - jsonpatch
           - boto3>=1.18.0
           - botocore>=1.21.0
-        # extra_args: --user
+        extra_args: --user
 
 - name: Gather OIDC provider info
   import_playbook: playbooks/oidc/provision.yml

--- a/ansible/deploy.yml
+++ b/ansible/deploy.yml
@@ -12,7 +12,7 @@
           - jsonpatch
           - boto3>=1.18.0
           - botocore>=1.21.0
-        extra_args: --user
+        # extra_args: --user
 
 - name: Gather OIDC provider info
   import_playbook: playbooks/oidc/provision.yml

--- a/ansible/generate_spec.yml
+++ b/ansible/generate_spec.yml
@@ -10,3 +10,5 @@
   when: alertmanager is defined
 - import_playbook: playbooks/lil/main.yml
   when: dex_balance_monitor_enabled
+- import_playbook: playbooks/ethproxy/main.yml
+  when: ethproxy is defined

--- a/ansible/playbooks/ethproxy/config/ethproxy-multi.yml.j2
+++ b/ansible/playbooks/ethproxy/config/ethproxy-multi.yml.j2
@@ -1,0 +1,127 @@
+---
+# Generate resources per enabled chainlet
+{% set chainlets = (ethproxy.chainlets if ethproxy is defined and ethproxy.chainlets is defined else []) %}
+{% for chainlet in chainlets if (chainlet.enabled | default(false)) %}
+{% set slug = (chainlet.chain_id | lower | replace('_','-')) %}
+{% set ns = 'saga-' + slug %}
+{% set version = (chainlet.version | default(ethproxy.version) | mandatory) %}
+{% set _rpc_suffixes = rpc_url_suffixes if rpc_url_suffixes is defined else ( [rpc_generic_url_suffix, url_suffix] if rpc_generic_url_suffix is defined else ( [url_suffix] if url_suffix is defined else [] ) ) %}
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ ns }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ethproxy-config-{{ slug }}
+  namespace: {{ ns }}
+data:
+  ethproxy.yml: |
+{% filter indent(width=4, first=True) %}
+{% set cosmos_url_ro = chainlet.cosmos_url_ro %}
+{% set cosmos_url_rw = chainlet.cosmos_url_rw %}
+{% set evm_url = chainlet.evm_url %}
+{% set chain_id = chainlet.chain_id %}
+{% include 'includes/ethproxy.yml.j2' %}
+
+{% endfilter %}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ethproxy-secrets-{{ slug }}
+  namespace: {{ ns }}
+stringData:
+  FEEPAYER_KEYS: "{{ chainlet.feepayer_private_keys | join(',') }}"
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: ethproxy
+  namespace: {{ ns }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ethproxy
+  template:
+    metadata:
+      labels:
+        app: ethproxy
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    spec:
+      containers:
+      - name: ethproxy
+        image: "sagaxyz/ethproxy:{{ version }}"
+        command:
+        - /bin/sh
+        - -c
+        - |
+          INDEX=${HOSTNAME##*-}
+          export ETHPROXY_SERVICES_FEE_PAYER_PRIVATE_KEYS=$(echo $FEEPAYER_KEYS | tr ',' '\n' | sed -n "$((INDEX+1))p")
+          exec /usr/bin/ethproxy -config /etc/saga/ethproxy/ethproxy.yml
+        envFrom:
+        - secretRef:
+            name: ethproxy-secrets-{{ slug }}
+        ports:
+        - containerPort: 8545
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/saga/ethproxy
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "1"
+          limits:
+            memory: "2Gi"
+            cpu: "2"
+      volumes:
+      - name: config-volume
+        configMap:
+          name: ethproxy-config-{{ slug }}
+          items:
+          - key: ethproxy.yml
+            path: ethproxy.yml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ethproxy
+  namespace: {{ ns }}
+spec:
+  selector:
+    app: ethproxy
+  ports:
+  - port: 8545
+    targetPort: 8545
+{% if _rpc_suffixes | length > 0 %}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "ingress-ethproxy-jsonrpc"
+  namespace: {{ ns }}
+  annotations:
+    saga.xyz/ingress-protocol: "jsonrpc"
+spec:
+  ingressClassName: nginx
+  rules:
+{% for url in _rpc_suffixes %}
+    - host: "{{ slug }}-ethproxy.jsonrpc.{{ url }}"
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ethproxy
+                port:
+                  number: 8545
+{% endfor %}
+{% endif %}
+
+{% endfor %}

--- a/ansible/playbooks/ethproxy/config/ethproxy-multi.yml.j2
+++ b/ansible/playbooks/ethproxy/config/ethproxy-multi.yml.j2
@@ -1,38 +1,29 @@
 ---
 # Generate resources per enabled chainlet
-{% set chainlets = (ethproxy.chainlets if ethproxy is defined and ethproxy.chainlets is defined else []) %}
-{% for chainlet in chainlets if (chainlet.enabled | default(false)) %}
-{% set slug = (chainlet.chain_id | lower | replace('_','-')) %}
-{% set ns = 'saga-' + slug %}
-{% set version = (chainlet.version | default(ethproxy.version) | mandatory) %}
-{% set _rpc_suffixes = rpc_url_suffixes if rpc_url_suffixes is defined else ( [rpc_generic_url_suffix, url_suffix] if rpc_generic_url_suffix is defined else ( [url_suffix] if url_suffix is defined else [] ) ) %}
+{% for chainlet in ethproxy_chainlets | default([]) %}
 ---
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ ns }}
+  name: {{ chainlet.ethproxy_namespace }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ethproxy-config-{{ slug }}
-  namespace: {{ ns }}
+  name: ethproxy-config-{{ chainlet.ethproxy_slug }}
+  namespace: {{ chainlet.ethproxy_namespace }}
 data:
   ethproxy.yml: |
 {% filter indent(width=4, first=True) %}
-{% set cosmos_url_ro = chainlet.cosmos_url_ro %}
-{% set cosmos_url_rw = chainlet.cosmos_url_rw %}
-{% set evm_url = chainlet.evm_url %}
-{% set chain_id = chainlet.chain_id %}
 {% include 'includes/ethproxy.yml.j2' %}
-
+ 
 {% endfilter %}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ethproxy-secrets-{{ slug }}
-  namespace: {{ ns }}
+  name: ethproxy-secrets-{{ chainlet.ethproxy_slug }}
+  namespace: {{ chainlet.ethproxy_namespace }}
 stringData:
   FEEPAYER_KEYS: "{{ chainlet.feepayer_private_keys | join(',') }}"
 ---
@@ -40,7 +31,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: ethproxy
-  namespace: {{ ns }}
+  namespace: {{ chainlet.ethproxy_namespace }}
 spec:
   replicas: 1
   selector:
@@ -56,7 +47,7 @@ spec:
     spec:
       containers:
       - name: ethproxy
-        image: "sagaxyz/ethproxy:{{ version }}"
+        image: "sagaxyz/ethproxy:{{ chainlet.ethproxy_version }}"
         command:
         - /bin/sh
         - -c
@@ -66,7 +57,7 @@ spec:
           exec /usr/bin/ethproxy -config /etc/saga/ethproxy/ethproxy.yml
         envFrom:
         - secretRef:
-            name: ethproxy-secrets-{{ slug }}
+            name: ethproxy-secrets-{{ chainlet.ethproxy_slug }}
         ports:
         - containerPort: 8545
         volumeMounts:
@@ -80,38 +71,38 @@ spec:
             memory: "2Gi"
             cpu: "2"
       volumes:
-      - name: config-volume
-        configMap:
-          name: ethproxy-config-{{ slug }}
-          items:
-          - key: ethproxy.yml
-            path: ethproxy.yml
+        - name: config-volume
+          configMap:
+            name: ethproxy-config-{{ chainlet.ethproxy_slug }}
+            items:
+              - key: ethproxy.yml
+                path: ethproxy.yml
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: ethproxy
-  namespace: {{ ns }}
+  namespace: {{ chainlet.ethproxy_namespace }}
 spec:
   selector:
     app: ethproxy
   ports:
   - port: 8545
     targetPort: 8545
-{% if _rpc_suffixes | length > 0 %}
+{% if ethproxy_rpc_suffixes | length > 0 %}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "ingress-ethproxy-jsonrpc"
-  namespace: {{ ns }}
+  namespace: {{ chainlet.ethproxy_namespace }}
   annotations:
     saga.xyz/ingress-protocol: "jsonrpc"
 spec:
   ingressClassName: nginx
   rules:
-{% for url in _rpc_suffixes %}
-    - host: "{{ slug }}-ethproxy.jsonrpc.{{ url }}"
+{% for url in ethproxy_rpc_suffixes %}
+    - host: "{{ chainlet.ethproxy_slug }}-ethproxy.jsonrpc.{{ url }}"
       http:
         paths:
           - path: /

--- a/ansible/playbooks/ethproxy/config/includes/ethproxy.yml.j2
+++ b/ansible/playbooks/ethproxy/config/includes/ethproxy.yml.j2
@@ -1,6 +1,6 @@
 loglevel: "trace"
-node_rpc: "{{ chainlet.cosmos_url_ro | default('tcp://chainlet:26657') }}"
-node_json_rpc: "{{ chainlet.evm_url | default('http://chainlet:8545') }}"
+node_rpc: "tcp://chainlet:26657"
+node_json_rpc: "http://chainlet:8545"
 chain_id: "{{ chainlet.chain_id }}"
 account_address_prefix: "saga"
 json_rpc_request_timeout: "10s"
@@ -22,7 +22,7 @@ services:
     enabled: true
     private_keys:
       - "redacted"
-    broadcast_node_rpc: "{{ chainlet.cosmos_url_rw | default('tcp://chainlet:26657') }}"
+    broadcast_node_rpc: "tcp://chainlet:26657"
     param_fetch_interval: "3s"
     check_gas:
       enabled: true

--- a/ansible/playbooks/ethproxy/config/includes/ethproxy.yml.j2
+++ b/ansible/playbooks/ethproxy/config/includes/ethproxy.yml.j2
@@ -1,7 +1,7 @@
 loglevel: "trace"
-node_rpc: "{{ cosmos_url_ro | default('tcp://chainlet-ro:26657') }}"
-node_json_rpc: "{{ evm_url | default('http://chainlet-ro:8545') }}"
-chain_id: "{{ chain_id | default(dex_chain_id) }}"
+node_rpc: "{{ chainlet.cosmos_url_ro | default('tcp://chainlet:26657') }}"
+node_json_rpc: "{{ chainlet.evm_url | default('http://chainlet:8545') }}"
+chain_id: "{{ chainlet.chain_id }}"
 account_address_prefix: "saga"
 json_rpc_request_timeout: "10s"
 server:
@@ -22,7 +22,7 @@ services:
     enabled: true
     private_keys:
       - "redacted"
-    broadcast_node_rpc: "{{ cosmos_url_rw | default('tcp://chainlet-rw:26657') }}"
+    broadcast_node_rpc: "{{ chainlet.cosmos_url_rw | default('tcp://chainlet:26657') }}"
     param_fetch_interval: "3s"
     check_gas:
       enabled: true

--- a/ansible/playbooks/ethproxy/config/includes/ethproxy.yml.j2
+++ b/ansible/playbooks/ethproxy/config/includes/ethproxy.yml.j2
@@ -1,0 +1,29 @@
+loglevel: "trace"
+node_rpc: "{{ cosmos_url_ro | default('tcp://chainlet-ro:26657') }}"
+node_json_rpc: "{{ evm_url | default('http://chainlet-ro:8545') }}"
+chain_id: "{{ chain_id | default(dex_chain_id) }}"
+account_address_prefix: "saga"
+json_rpc_request_timeout: "10s"
+server:
+  json_rpc:
+    address: "0.0.0.0:8545"
+    http_timeout: "30s"
+    http_idle_timeout: "60s"
+    rate_limit:
+      enabled: false
+      ip_header: "True-Client-IP"
+      rate: 35_000
+      burst: 10_000_000
+  prometheus:
+    enabled: true
+    address: "0.0.0.0:9090"
+services:
+  fee_payer:
+    enabled: true
+    private_keys:
+      - "redacted"
+    broadcast_node_rpc: "{{ cosmos_url_rw | default('tcp://chainlet-rw:26657') }}"
+    param_fetch_interval: "3s"
+    check_gas:
+      enabled: true
+      max_delta: 10

--- a/ansible/playbooks/ethproxy/main.yml
+++ b/ansible/playbooks/ethproxy/main.yml
@@ -1,0 +1,19 @@
+- hosts: eks_clusters
+  gather_facts: false
+
+  vars_files:
+    - vars/main.yml
+
+  tasks:
+    - name: Create a directory if it does not exist
+      ansible.builtin.file:
+        path: ~/.ansible/deployments/{{ eks_cluster_name }}
+        state: directory
+        mode: '0744'
+    - name: Generate ethproxy multi-chainlet spec
+      ansible.builtin.template:
+        src: config/ethproxy-multi.yml.j2
+        dest: ~/.ansible/deployments/{{ eks_cluster_name }}/deploy-ethproxy.yml
+        mode: '0644'
+      when:
+        - ethproxy is defined

--- a/ansible/playbooks/ethproxy/main.yml
+++ b/ansible/playbooks/ethproxy/main.yml
@@ -5,12 +5,47 @@
     - vars/main.yml
 
   tasks:
+    - name: Init ethproxy_chainlets list
+      ansible.builtin.set_fact:
+        ethproxy_chainlets: []
+      when: ethproxy is defined
+
+    - name: Build ethproxy chainlets data
+      ansible.builtin.set_fact:
+        ethproxy_chainlets: >-
+          {{ ethproxy_chainlets + [
+              item | combine({
+                'ethproxy_slug': (item.chain_id | lower | replace('_','-')),
+                'ethproxy_namespace': ('saga-' + (item.chain_id | lower | replace('_','-'))),
+                'ethproxy_version': (item.version | default(ethproxy.version))
+              })
+            ]
+          }}
+      loop: "{{ (ethproxy.chainlets | default([])) | selectattr('enabled','defined') | selectattr('enabled') | list }}"
+      loop_control:
+        label: "{{ item.chain_id }}"
+      when: ethproxy is defined
+
+    - name: Compute ethproxy RPC URL suffixes
+      ansible.builtin.set_fact:
+        ethproxy_rpc_suffixes: >-
+          {{
+            rpc_url_suffixes if (rpc_url_suffixes is defined)
+            else (
+              ([rpc_generic_url_suffix, url_suffix]) if (rpc_generic_url_suffix is defined)
+              else (([url_suffix]) if (url_suffix is defined) else [])
+            )
+          }}
+      when: ethproxy is defined
     - name: Create a directory if it does not exist
       ansible.builtin.file:
         path: ~/.ansible/deployments/{{ eks_cluster_name }}
         state: directory
         mode: '0744'
     - name: Generate ethproxy multi-chainlet spec
+      vars:
+        ethproxy_chainlets: "{{ ethproxy_chainlets }}"
+        ethproxy_rpc_suffixes: "{{ ethproxy_rpc_suffixes }}"
       ansible.builtin.template:
         src: config/ethproxy-multi.yml.j2
         dest: ~/.ansible/deployments/{{ eks_cluster_name }}/deploy-ethproxy.yml

--- a/ansible/playbooks/k8s/apply.yml
+++ b/ansible/playbooks/k8s/apply.yml
@@ -362,3 +362,11 @@
       when:
         - ibc_tester is defined
         - ibc_tester.enabled | bool
+
+    - name: Apply ethproxy deployment spec
+      kubernetes.core.k8s:
+        kubeconfig: "{{ k8s_kubeconfig }}"
+        state: present
+        src: ~/.ansible/deployments/{{ eks_cluster_name }}/deploy-ethproxy.yml
+      when:
+        - ethproxy is defined


### PR DESCRIPTION
Deploying ethproxy for user chainlets. See https://github.com/sagaxyz/infrastructure-configs/pull/5 for config example. Tested in staging. To test, take the example config, adjust to your chainlet values and run deploy.